### PR TITLE
make boost discoverable by CMake

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -740,3 +740,4 @@ class Boost(Package):
                 env.append_flags("CXXFLAGS", "-DBOOST_USE_UCONTEXT")
             elif context_impl == "winfib":
                 env.append_flags("CXXFLAGS", "-DBOOST_USE_WINFIB")
+        env.set("Boost_INCLUDE_DIR", self.prefix.inc)


### PR DESCRIPTION
Add Boost_INCLUDE_DIR to expose boost to dependent CMakePackages.